### PR TITLE
Fix chat edit box being covered by chat messages when virtual keyboard is disabled

### DIFF
--- a/chat/chat.lua
+++ b/chat/chat.lua
@@ -25,6 +25,11 @@ Chat.chatFrameOriginalState = {
     color = nil,
     alpha = nil
 }
+Chat.chatEditBoxOriginalState = {
+    strata = nil,
+    level = nil,
+    saved = false
+}
 
 -- Save original chat frame state
 function Chat:SaveChatFrameState()
@@ -79,6 +84,29 @@ function Chat:RestoreChatFrameState()
             end
         end
     end
+end
+
+-- Save original chat edit box layer state
+function Chat:SaveChatEditBoxLayerState()
+    if not ChatFrameEditBox or self.chatEditBoxOriginalState.saved then return end
+
+    self.chatEditBoxOriginalState.strata = ChatFrameEditBox:GetFrameStrata()
+    self.chatEditBoxOriginalState.level = ChatFrameEditBox:GetFrameLevel()
+    self.chatEditBoxOriginalState.saved = true
+end
+
+-- Restore original chat edit box layer state
+function Chat:RestoreChatEditBoxLayerState()
+    if not ChatFrameEditBox or not self.chatEditBoxOriginalState.saved then return end
+
+    if self.chatEditBoxOriginalState.strata then
+        ChatFrameEditBox:SetFrameStrata(self.chatEditBoxOriginalState.strata)
+    end
+    if self.chatEditBoxOriginalState.level then
+        ChatFrameEditBox:SetFrameLevel(self.chatEditBoxOriginalState.level)
+    end
+
+    self.chatEditBoxOriginalState.saved = false
 end
 
 -- Get anchor frame for chat positioning (when edit box is hidden)
@@ -185,6 +213,9 @@ function Chat:Disable()
     if self.oskHelper then
         self.oskHelper:Hide()
     end
+
+    -- Restore edit box layers if we elevated them
+    self:RestoreChatEditBoxLayerState()
     
     CE_Debug("Chat: Disable completed")
 end
@@ -367,6 +398,12 @@ function Chat:ManagePositions(a1, a2, a3)
                     ChatFrame1:SetFrameStrata("DIALOG")
                     ChatFrame1:SetFrameLevel(100)
                     ChatFrame1:SetAlpha(1.0)
+
+                    -- Keep edit box above focused chat messages
+                    self:SaveChatEditBoxLayerState()
+                    ChatFrameEditBox:SetFrameStrata("DIALOG")
+                    ChatFrameEditBox:SetFrameLevel(ChatFrame1:GetFrameLevel() + 20)
+                    ChatFrameEditBox:Raise()
                     
                     -- Position from top, starting BELOW the edit box
                     -- Top edge starts below edit box, bottom edge at editBoxOffset + chatHeight from top
@@ -413,6 +450,7 @@ function Chat:ManagePositions(a1, a2, a3)
                     ChatFrame1:SetFrameStrata("BACKGROUND")
                     ChatFrame1:SetFrameLevel(1)
                 end
+                self:RestoreChatEditBoxLayerState()
                 
                 -- Force update to ensure we restore the configured layout
                 self:UpdateChatLayout(true)
@@ -567,4 +605,3 @@ function Chat:Initialize()
     self.initialized = true
     CE_Debug("Chat frame module initialized")
 end
-

--- a/keyboard/keyboard.lua
+++ b/keyboard/keyboard.lua
@@ -1608,14 +1608,21 @@ function Keyboard:Initialize()
             if oldOnShow then
                 oldOnShow()
             end
+            if ChatFrameEditBox then
+                ChatFrameEditBox:Raise()
+            end
             -- Show keyboard when chat edit box is shown (only if keyboard is enabled)
             local config = ConsoleExperience.config
             if ConsoleExperience.keyboard and config and config:Get("keyboardEnabled") then
                 ConsoleExperience.keyboard:Show(ChatFrameEditBox)
+                if ChatFrameEditBox then
+                    ChatFrameEditBox:Raise()
+                end
             else
                 -- Keyboard is disabled - ensure ChatFrameEditBox has proper focus and keyboard input
                 if ChatFrameEditBox then
                     ChatFrameEditBox:EnableKeyboard(true)
+                    ChatFrameEditBox:Raise()
                     -- Use a small delay to ensure focus is set after the edit box is fully shown
                     local focusFrame = CreateFrame("Frame")
                     focusFrame:SetScript("OnUpdate", function()
@@ -1624,6 +1631,7 @@ function Keyboard:Initialize()
                             this:SetScript("OnUpdate", nil)
                             if ChatFrameEditBox and ChatFrameEditBox:IsVisible() then
                                 ChatFrameEditBox:SetFocus()
+                                ChatFrameEditBox:Raise()
                             end
                         end
                     end)
@@ -1731,4 +1739,3 @@ SlashCmdList["CELISTCMDS"] = function()
 end
 
 -- Module loaded silently
-


### PR DESCRIPTION
## Summary
This PR fixes a chat layering issue in `ConsoleExperienceClassic` where opening chat with **virtual keyboard disabled** can cause the `ChatFrameEditBox` to be visually covered by incoming chat messages (commonly seen with busy world channels).

## Problem
When chat enters focused mode, CE promotes `ChatFrame1` to `DIALOG` with a high frame level for the expanded chat view. However, with virtual keyboard disabled, `ChatFrameEditBox` was only focused (`SetFocus`) and raised, without explicit layer promotion above `ChatFrame1`.

Result: message regions in the promoted chat frame could render over the edit box, making the input line appear covered.

## Root Cause
- Focused mode elevates `ChatFrame1` (`SetFrameStrata("DIALOG")`, `SetFrameLevel(100)`).
- `ChatFrameEditBox` did not have guaranteed strata/level higher than focused `ChatFrame1`.
- In keyboard-disabled flow, delayed focus callbacks could still leave the edit box below message rendering.

## What this PR changes
### 1) Add explicit edit box layer state management in `chat/chat.lua`
- Save original `ChatFrameEditBox` strata/level once before elevation.
- In focused chat mode, force edit box above chat messages:
  - `SetFrameStrata("DIALOG")`
  - `SetFrameLevel(ChatFrame1:GetFrameLevel() + 20)`
  - `Raise()`
- Restore original strata/level when chat edit box is hidden.
- Also restore on chat module disable to avoid sticky layering side effects.

### 2) Add OnShow safety raises in `keyboard/keyboard.lua`
- Always call `ChatFrameEditBox:Raise()` in `OnShow` hook.
- Keep the same safeguard in both keyboard-enabled and keyboard-disabled branches.
- In keyboard-disabled delayed-focus path, call `Raise()` again after `SetFocus()`.

## Why this approach
- Keeps existing CE UX unchanged (top-positioned edit box, focused expanded chat, keyboard toggle semantics).
- Fixes the layering deterministically instead of relying on focus timing/order.
- Restores original layer state to avoid impacting unrelated UI panels.

## Validation scenarios
- `keyboardEnabled=false`: open chat via Enter, CE radial chat button, and channel-button addons (e.g. S_ChatBar) -> edit box stays above messages.
- `keyboardEnabled=true`: virtual keyboard behavior unchanged.
- Close chat and open other panels (bags/character/config) -> no persistent edit box layering anomalies.
